### PR TITLE
Streaming feature

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -4,6 +4,8 @@ https://github.com/nicklan/Deluge-Pieces-Plugin
 (c)2010 by Nick Lanham <nick@afternight.org>
 Thanks to Jens Timmerman <jens.timmerman@gmail.com> for some of the
 code to select multiple pieces
+Thanks to Lex Leonard <lexman098@gmail.com> for some of the
+code to enhance streaming of pieces
 
 ## Description
 
@@ -32,17 +34,17 @@ You can select multiple pieces in a few ways:
 
 
 Underneath all the pieces is a checkbox that will allow you to always
-prioritize the first un-downloaded piece of the torrent. This lets you
-start watching a movie while it is still downloading. After completing
-the torrent you should continue to seed for a while, because this
-behaviour is actually not sociable and bad for the torrent
-protocol. Please use with care. 
+prioritize the first un-downloaded pieces of the torrent. This lets you
+start watching a movie while it is still downloading. 
 
 
 To install this plugin in deluge: go to edit, preferences, plugins,
 install plugin and select the .egg file.
 
 # Version Info
+
+## Version 0.6
+* Added streaming of more than 1 piece (set to 15)
 
 ## Version 0.5
 * Plugin works in client/server and "Classic" mode

--- a/pieces/data/pieces.js
+++ b/pieces/data/pieces.js
@@ -35,7 +35,7 @@ Ext.namespace('Deluge.pieces');
 var dh = Ext.DomHelper;
 
 Deluge.pieces.PiecesTab = Ext.extend(Ext.Panel, {
-		title: _('Pieces lex'),
+		title: _('Pieces'),
 
 		constructor: function() {
 			Deluge.pieces.PiecesTab.superclass.constructor.call(this);
@@ -160,7 +160,7 @@ Deluge.pieces.PiecesTab = Ext.extend(Ext.Panel, {
 });
 
 Deluge.pieces.PiecesPlugin = Ext.extend(Deluge.Plugin, {
-		name:"Pieces lex",
+		name:"Pieces",
 
 		onDisable: function() {
 
@@ -171,4 +171,4 @@ Deluge.pieces.PiecesPlugin = Ext.extend(Deluge.Plugin, {
 		}
 
 });
-Deluge.registerPlugin('Pieces lex',Deluge.pieces.PiecesPlugin);
+Deluge.registerPlugin('Pieces',Deluge.pieces.PiecesPlugin);

--- a/pieces/data/pieces.js
+++ b/pieces/data/pieces.js
@@ -35,7 +35,7 @@ Ext.namespace('Deluge.pieces');
 var dh = Ext.DomHelper;
 
 Deluge.pieces.PiecesTab = Ext.extend(Ext.Panel, {
-		title: _('Pieces'),
+		title: _('Pieces lex'),
 
 		constructor: function() {
 			Deluge.pieces.PiecesTab.superclass.constructor.call(this);
@@ -160,7 +160,7 @@ Deluge.pieces.PiecesTab = Ext.extend(Ext.Panel, {
 });
 
 Deluge.pieces.PiecesPlugin = Ext.extend(Deluge.Plugin, {
-		name:"Pieces",
+		name:"Pieces lex",
 
 		onDisable: function() {
 
@@ -171,4 +171,4 @@ Deluge.pieces.PiecesPlugin = Ext.extend(Deluge.Plugin, {
 		}
 
 });
-Deluge.registerPlugin('Pieces',Deluge.pieces.PiecesPlugin);
+Deluge.registerPlugin('Pieces lex',Deluge.pieces.PiecesPlugin);

--- a/pieces/gtkui.py
+++ b/pieces/gtkui.py
@@ -342,7 +342,7 @@ class PiecesTab(Tab):
         Tab.__init__(self)
         glade_tab = gtk.glade.XML(get_resource("pieces_tab.glade"))
 
-        self._name = "Pieces"
+        self._name = "Pieces_lex"
         self._child_widget = glade_tab.get_widget("pieces_tab")
         self._tab_label = glade_tab.get_widget("pieces_tab_label")
 
@@ -457,18 +457,18 @@ class GtkUI(GtkPluginBase):
         component.get("TorrentDetails").add_tab(self._pieces_tab)
         client.pieces.get_config().addCallback(self.set_colors)
 
-        component.get("Preferences").add_page("Pieces", self.glade_cfg.get_widget("prefs_box"))
+        component.get("Preferences").add_page("Pieces_lex", self.glade_cfg.get_widget("prefs_box"))
         component.get("PluginManager").register_hook("on_apply_prefs", self.on_apply_prefs)
         component.get("PluginManager").register_hook("on_show_prefs", self.on_show_prefs)
 
     def disable(self):
-        component.get("Preferences").remove_page("Pieces")
-        component.get("TorrentDetails").remove_tab("Pieces")
+        component.get("Preferences").remove_page("Pieces_lex")
+        component.get("TorrentDetails").remove_tab("Pieces_lex")
         component.get("PluginManager").deregister_hook("on_apply_prefs", self.on_apply_prefs)
         component.get("PluginManager").deregister_hook("on_show_prefs", self.on_show_prefs)
 
     def on_apply_prefs(self):
-        log.debug("applying prefs for Pieces")
+        log.debug("applying prefs for Pieces_lex")
         config = {
             "not_dled_color":self.glade_cfg.get_widget("not_dl_button").get_color().to_string(),
             "dled_color":self.glade_cfg.get_widget("dl_button").get_color().to_string(),

--- a/pieces/gtkui.py
+++ b/pieces/gtkui.py
@@ -342,7 +342,7 @@ class PiecesTab(Tab):
         Tab.__init__(self)
         glade_tab = gtk.glade.XML(get_resource("pieces_tab.glade"))
 
-        self._name = "Pieces_lex"
+        self._name = "Pieces"
         self._child_widget = glade_tab.get_widget("pieces_tab")
         self._tab_label = glade_tab.get_widget("pieces_tab_label")
 
@@ -352,7 +352,7 @@ class PiecesTab(Tab):
 
         vb = gtk.VBox()
         vb.add(self._ms)
-        self.cb = gtk.CheckButton(label="Set priority of first un-downloaded piece to High")
+        self.cb = gtk.CheckButton(label="Set priority of first few un-downloaded pieces to High")
         self.cb.connect("toggled",self.onPrioTogg)
         vb.pack_end(self.cb,expand=False,fill=False,padding=5)
 
@@ -390,7 +390,7 @@ class PiecesTab(Tab):
                                gtk.DIALOG_MODAL,
                                gtk.MESSAGE_WARNING,
                                gtk.BUTTONS_OK,
-                               "Using this option is rather unsocial and not particularly good for the torrent protocol.\n\nPlease use with care, and seed the torrent afterwards if you use this.")
+                               "Using this option for torrents with an unhealthy swarm is rather unsocial and not particularly good for the swarm.\n\nPlease use with care.")
         md.connect('response', self.__dest)
         md.show_all()
         return False
@@ -457,18 +457,18 @@ class GtkUI(GtkPluginBase):
         component.get("TorrentDetails").add_tab(self._pieces_tab)
         client.pieces.get_config().addCallback(self.set_colors)
 
-        component.get("Preferences").add_page("Pieces_lex", self.glade_cfg.get_widget("prefs_box"))
+        component.get("Preferences").add_page("Pieces", self.glade_cfg.get_widget("prefs_box"))
         component.get("PluginManager").register_hook("on_apply_prefs", self.on_apply_prefs)
         component.get("PluginManager").register_hook("on_show_prefs", self.on_show_prefs)
 
     def disable(self):
-        component.get("Preferences").remove_page("Pieces_lex")
-        component.get("TorrentDetails").remove_tab("Pieces_lex")
+        component.get("Preferences").remove_page("Pieces")
+        component.get("TorrentDetails").remove_tab("Pieces")
         component.get("PluginManager").deregister_hook("on_apply_prefs", self.on_apply_prefs)
         component.get("PluginManager").deregister_hook("on_show_prefs", self.on_show_prefs)
 
     def on_apply_prefs(self):
-        log.debug("applying prefs for Pieces_lex")
+        log.debug("applying prefs for Pieces")
         config = {
             "not_dled_color":self.glade_cfg.get_widget("not_dl_button").get_color().to_string(),
             "dled_color":self.glade_cfg.get_widget("dl_button").get_color().to_string(),

--- a/pieces/priority_thread.py
+++ b/pieces/priority_thread.py
@@ -63,14 +63,12 @@ def priority_loop(meth):
 
                 #loop until we've marked the next undownloaded piece
                 while (tor.handle.have_piece(i_piece) == True): #downloaded by now
-                    #print "incrementing base"
                     i_piece += 1
 
                     #find number of pieces after i_piece that are marked for download
                     #i=index (starting at i_piece), p=priority
                     for (i,p) in enumerate(prios[i_piece:]):
                         if p > 0:
-                            #print "found next base at: ", i
                             i_piece = i + i_piece
                             break
 
@@ -79,7 +77,6 @@ def priority_loop(meth):
                 #loop again and mark __n_extra pieces for higher priority
                 for (i,p) in enumerate(prios[i_piece:]):
                     if n >= __n_extra:
-                        #print "n is done"
                         break
 
                     if p > 0: #marked for download
@@ -87,13 +84,11 @@ def priority_loop(meth):
 
                         if (tor.handle.have_piece(j_piece) == False): #not downloaded yet
                             n += 1
-                            #print "found one, n at: ", n
 
                             if (tor.handle.piece_priority(j_piece) < __target_priority):
                                 tor.handle.piece_priority(j_piece, __target_priority)
 
                 __last_first[t] = i_piece
-                #print "sequence done \n"
 
             except ValueError:
                 continue

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ from setuptools import setup
 __plugin_name__ = "Pieces"
 __author__ = "Nick Lanham"
 __author_email__ = "nick@afternight.org"
-__version__ = "0.5"
+__version__ = "0.6"
 __url__ = "https://github.com/nicklan/Deluge-Pieces-Plugin"
 __license__ = "GPLv3"
 __description__ = "Add a tab showing the status of each piece of the selected torrent"
@@ -72,11 +72,8 @@ You can select multiple pieces in a few ways.
 
 
 Underneath all the pieces is a checkbox that will allow you to always
-prioritize the first un-downloaded piece of the torrent. This lets you
-start watching a movie while it is still downloading. After completing
-the torrent you should continue to seed for a while, because this
-behaviour is actually not sociable and bad for the torrent
-protocol. Please use with care. 
+prioritize the first un-downloaded pieces of the torrent. This lets you
+start watching a movie while it is still downloading. 
 """
 __pkg_data__ = {__plugin_name__.lower(): ["template/*", "data/*"]}
 


### PR DESCRIPTION
I've upgraded the priority_thread.py to stream the first 15 undownloaded pieces instead of just 1 when checking the box. Since modern torrents on modern connections usually download many pieces at once (very quickly) it's not useful to prioritize just 1 at a time. 

If you decide to merge this, another cool feature would be an input box to tell it how many pieces you want to stream in the form of a percentage of total pieces in the torrent.